### PR TITLE
Use Python 3, instead of the default of the machine

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,6 +2,7 @@
 remote_user = root
 host_key_checking = true
 inventory = inventory/staging.yml
+interpreter_python = /usr/bin/python3
 
 [privilege_escalation]
 become = False

--- a/inventory/production.yml
+++ b/inventory/production.yml
@@ -1,7 +1,5 @@
 ---
 all:
-  vars:
-    ansible_python_interpreter: auto
   hosts:
     obs:
       ansible_connection: ssh

--- a/inventory/production.yml
+++ b/inventory/production.yml
@@ -5,5 +5,5 @@ all:
       ansible_connection: ssh
       # configured host in your ssh config
       ansible_host: obs
-      apache_sysconfig_regex_unset: 'APACHE_SERVER_FLAGS="STATUS"' 
+      apache_sysconfig_regex_unset: 'APACHE_SERVER_FLAGS="STATUS"'
       apache_sysconfig_regex_set: 'APACHE_SERVER_FLAGS="STATUS MAINTENANCE"'

--- a/inventory/staging.yml
+++ b/inventory/staging.yml
@@ -1,7 +1,5 @@
 ---
 all:
-  vars:
-    ansible_python_interpreter: auto
   hosts:
     obs:
       ansible_connection: ssh

--- a/inventory/staging.yml
+++ b/inventory/staging.yml
@@ -7,7 +7,7 @@ all:
       ansible_port: 2222
       # in the production inventory it should look like:
       # 'APACHE_SERVER_FLAGS=\"STATUS\"'
-      apache_sysconfig_regex_unset: 'APACHE_SERVER_FLAGS="SSL"' 
+      apache_sysconfig_regex_unset: 'APACHE_SERVER_FLAGS="SSL"'
       # in production inventory it should look like:
       # 'APACHE_SERVER_FLAGS=\"STATUS MAINTENANCE\"'
       apache_sysconfig_regex_set: 'APACHE_SERVER_FLAGS="SSL MAINTENANCE"'


### PR DESCRIPTION
Let's try with Python 3, and only fall back explicitly to Python 2 if some playbook cannot be run.

This also prevents this warning from appearing on each `ansible` run:

```
[WARNING]: Platform linux on host obs is using the discovered Python interpreter at /usr/bin/python,
but future installation of another Python interpreter could change this. See
https://docs.ansible.com/ansible/2.9/reference_appendices/interpreter_discovery.html for more information.
```