### PR TITLE
Auto-import gpg signing keys for the repositories

### DIFF
--- a/roles/refresh_repositories/tasks/main.yml
+++ b/roles/refresh_repositories/tasks/main.yml
@@ -6,3 +6,4 @@
     zypper_repository: 
       repo: '*'
       runrefresh: yes
+      auto_import_keys: yes


### PR DESCRIPTION
Avoid "Signature verification failed for repomd.xml" errors when refreshing zypper repositories