### PR TITLE
Revert "Auto-import gpg signing keys for the repositories"

### DIFF
--- a/roles/refresh_repositories/tasks/main.yml
+++ b/roles/refresh_repositories/tasks/main.yml
@@ -6,4 +6,3 @@
     zypper_repository: 
       repo: '*'
       runrefresh: yes
-      auto_import_keys: yes


### PR DESCRIPTION
Reverts openSUSE/ansible-obs#5

Because we wouldn't be notified when someone swaps repositories, for example.

This means we have to manually accept the signing key the first time we refresh repositories.