### PR TITLE
Ignore pending migrations

### DIFF
--- a/deploy_with_migration.yml
+++ b/deploy_with_migration.yml
@@ -3,7 +3,6 @@
     hosts: obs
 
     pre_tasks:
-      - include_tasks: ./includes/pending-migration.yml
       - include_tasks: ./includes/deployment-block.yml
       - name: zypper unlock
         block:

--- a/deploy_with_migration_without_downtime.yml
+++ b/deploy_with_migration_without_downtime.yml
@@ -4,7 +4,6 @@
 
 
     pre_tasks:
-      - include_tasks: ./includes/pending-migration.yml
       - include_tasks: ./includes/deployment-block.yml
       - name: zypper unlock
         block:


### PR DESCRIPTION
We know there is a pending migration. We want to deploy anyway, that
is why we use those playbooks.