### PR TITLE
Fix ansible-lint errors

### DIFF
--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -6,13 +6,13 @@
 
 - name: debug task
   debug:
-    msg: "Called for {{inventory_hostname}}"
+    msg: "Called for {{ inventory_hostname }}"
   listen: ensure systemd
 
 - name: obs-delayed-consistency-check
   service: state=started name="{{item}}"
   listen: ensure systemd
-  loop: "{{systemd_services}}"
+  loop: "{{ systemd_services }}"
 
 - name: notify rocketchat
   shell: "bin/dotenv utilities/send_rocketchat_message {{ ansible_ssh_host }}"
@@ -21,7 +21,7 @@
 
 - name: run curl
   # change the url for
-  shell: "{{check_url}}"
+  shell: "{{ check_url }}"
   delegate_to: localhost
   listen: check_http_server_running
 

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -6,11 +6,13 @@
     delegate_to: localhost
     register: new_version_available
     ignore_errors: false
+    changed_when: false
   - name: There is pending migration
     shell: "{{ check_migration_command }}"
     delegate_to: localhost
     register: no_migration_available
     ignore_errors: true
+    changed_when: false
 
   - name: zypper up 'obs-api'
     command: 


### PR DESCRIPTION
Fixes the ansible-lint errors for the spaces before and after the curly braces and the "Commands should not change things if nothing needs doing". About the latter, ansible is unable to detect if the command under `shell` is producing
changes on the remote host or not. The `changed_when: false` tells ansible those commands do not change anything there.

Fixes #28 