### PR TITLE
Use openSUSE Leap 15.3 image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/tumbleweed
+FROM registry.opensuse.org/opensuse/leap:15.3
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000


### PR DESCRIPTION
openSUSE Tumbleweed is introducing big changes from time to time and being on the bleeding edge for our deployment tools isn't needed.