### PR TITLE
Stop using ruby version from outside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,22 @@
 FROM registry.opensuse.org/opensuse/leap:15.3
 
 ARG USER_ID=1000
-ARG GROUP_ID=1000
 ARG USER_NAME=foo
-
 
 RUN zypper -n install openssh-clients ansible ruby ruby-devel bash git libxml2-devel gcc make shadow vim curl
 RUN zypper -q clean -a
 
 RUN useradd -l -u ${USER_ID} -g users --home-dir /home/${USER_NAME} --create-home ${USER_NAME}
+
+RUN gem install bundler -v '~> 2.2'
+
+# Ensure there is bundle command without ruby suffix
+RUN for i in bundle bundler; do ln -s /usr/bin/$i.ruby2.5 /usr/local/bin/$i; done
+
+WORKDIR /home/${USER_NAME}/ansible-obs
+ADD Gemfile /home/${USER_NAME}/ansible-obs
+ADD Gemfile.lock /home/${USER_NAME}/ansible-obs
+RUN bundle install
 
 ADD "entrypoint.sh" /
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,6 @@
 
 cd /home/$USER/ansible-obs
 bundle install --deployment --binstubs
-bundle exec gem install bundler -v '~> 2.2'
-export GEM_PATH=vendor/bundle/ruby/2.7.0:$GEM_PATH
 
 echo "Have a lot of fun"
 


### PR DESCRIPTION
Since we moved from Tumbleweed to Leap, the ruby version inside the container is 2.5, however, the binstubs were created using the ruby version from the machine (outside Docker) which sometimes was different.

To avoid problems with different setups in the operators' machines, we make ansible-obs self-contained.

~We also take the opportunity to simplify the paths, replacing `/home/${USER}/ansible-obs` by `/home/ansible-obs`.~

Co-authored-by: Eduardo Navarro <enavarro@suse.com>