### PR TITLE
Fix checking for pending migrations in task `run_migrations`

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -7,18 +7,12 @@
     register: new_version_available
     ignore_errors: false
     changed_when: false
-  - name: There is pending migration
-    shell: "{{ check_migration_command }}"
-    delegate_to: localhost
-    register: no_migration_available
-    ignore_errors: true
-    changed_when: false
 
   - name: zypper up 'obs-api'
     command: 
       cmd: zypper -n update --best-effort --details obs-api
       warn: false
-    when: new_version_available.rc == 0 # and no_migration_available.rc == 0
+    when: new_version_available.rc == 0
     notify: 
       - ensure systemd
       - check_http_server_running

--- a/roles/run_migrations/tasks/main.yml
+++ b/roles/run_migrations/tasks/main.yml
@@ -5,12 +5,12 @@
     # or production server
     shell: "{{ check_migration_command }}"
     delegate_to: localhost
-    register: migration_available
+    register: no_pending_migration
     ignore_errors: False
 
   - name: run db migration
     shell: "source /root/.bashrc && run_in_api rails db:migrate"
-    when: migration_available is succeeded
+    when: no_pending_migration is failed
   - name: run data migration
     shell: "source /root/.bashrc && run_in_api rails db:migrate:with_data"
-    when: migration_available is succeeded
+    when: no_pending_migration is failed


### PR DESCRIPTION
Migrations and data migrations should be run when there are still pending migrations, that is, when the `check_migration_command` returns an error response.