### PR TITLE
Enable Flipper features for group

### DIFF
--- a/deploy_with_migration.yml
+++ b/deploy_with_migration.yml
@@ -21,6 +21,8 @@
           - include_role:
               name: run_migrations
           - include_role:
+              name: enable_flipper_features_for_group
+          - include_role:
               name: unset_apache_maintenance_mode
         when: deployment_allowed is succeeded and no_pending_migration is failed
 

--- a/deploy_with_migration_without_downtime.yml
+++ b/deploy_with_migration_without_downtime.yml
@@ -19,6 +19,8 @@
               name: deploy
           - include_role:
               name: run_migrations
+          - include_role:
+              name: enable_flipper_features_for_group
         when: deployment_allowed is succeeded and no_pending_migration is failed
 
     post_tasks:

--- a/deploy_without_migration.yml
+++ b/deploy_without_migration.yml
@@ -17,6 +17,8 @@
               name: refresh_repositories
           - include_role: 
               name: deploy
+          - include_role:
+              name: enable_flipper_features_for_group
         when: deployment_allowed is succeeded and no_pending_migration is succeeded
 
     post_tasks:

--- a/roles/enable_flipper_features_for_group/tasks/main.yml
+++ b/roles/enable_flipper_features_for_group/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+  - name: enable flipper features for group
+    shell: "source /root/.bashrc && run_in_api rails flipper:enable_features_for_group"


### PR DESCRIPTION
It's going to run for every deployment, but it's really minimal. Otherwise, it's too easy to forget to do this.