### PR TITLE
Using double splat to transform hash to keyword argument

### DIFF
--- a/utilities/new_version_available
+++ b/utilities/new_version_available
@@ -8,7 +8,8 @@ if host == "127.0.0.1"
     OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
     checkdiff_params[target_server] = "https://#{host}:8443"
 end
-check_diff = ObsDeploy::CheckDiff.new(checkdiff_params)
+
+check_diff = ObsDeploy::CheckDiff.new(**checkdiff_params)
 # 0 => new package available to deploy
 # 1 => no package available to deploy
 exit check_diff.new_version_available? ? 0 : 1


### PR DESCRIPTION
As described here https://mikerogers.io/2020/08/17/ruby-using-the-double-splat-with-keyword-arguments, in ruby 3 we have to transform it manually 