### PR TITLE
Upgrade ansible-lint version to fix CircleCI problems

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,3 @@
 skip_list:  # or 'skip_list' to silence them completely
   - command-instead-of-shell  # Use shell only when shell functionality is required
-
+  - no-changed-when

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
 ansible==4.2.0
-ansible-lint==5.0.12
+ansible-lint==5.3.2


### PR DESCRIPTION
Looks like there is an ansible-lint [version mismatch on CircleCI](https://app.circleci.com/pipelines/github/openSUSE/ansible-obs/33/workflows/9563ff3d-e1c4-4f46-a130-ea218b6ba141/jobs/34).
See https://github.com/ansible/ansible-lint/issues/1795