### PR TITLE
Fix the deprecation warning

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 cd /home/$USER/ansible-obs
-bundle.ruby3.1 config build.nokogiri --use-system-libraries && bundle.ruby3.1 install --deployment --binstubs
+bundle.ruby3.1 config set --local deployment 'true' &&
+bundle.ruby3.1 config build.nokogiri --use-system-libraries &&
+bundle.ruby3.1 install &&
+bundle.ruby3.1 binstubs --all
 
 echo "Have a lot of fun"
 


### PR DESCRIPTION
Running the docker container throws a deprecation like this one:

	[DEPRECATED] The `--deployment` flag is deprecated because it relies
	on being remembered across bundler invocations, which bundler will
	no longer do in future versions. Instead please use `bundle config
	set --local deployment 'true'`, and stop using this flag

and

	[DEPRECATED] The --binstubs option will be removed in favor of
	`bundle binstubs --all`