### PR TITLE
Disable warnings for zypper commands unsupported in zypper module

### DIFF
--- a/includes/zypper-lock.yml
+++ b/includes/zypper-lock.yml
@@ -1,3 +1,5 @@
 ---
   - name: lock obs-api
     shell: zypper al obs-api
+    args:
+      warn: false # To remove the warning `Consider using the zypper module rather than running 'zypper'`. This isn't possible since the module doesn't support locking packages.

--- a/includes/zypper-unlock.yml
+++ b/includes/zypper-unlock.yml
@@ -1,3 +1,5 @@
 ---
   - name: unlock obs-api
     shell: zypper rl obs-api
+    args:
+      warn: false # To remove the warning `Consider using the zypper module rather than running 'zypper'`. This isn't possible since the module doesn't support unlocking packages.


### PR DESCRIPTION
Closes #24

Sources about the changes:
- https://ansibledaily.com/avoid-ansible-command-warnings/
- http://www.freekb.net/Article?id=2384