### PR TITLE
Container & Docu cleanup

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,7 @@
-# GitHub credentials to access the repository where you are going to track the deployments.
-GITHUB_TOKEN=Personal Access Token with the scope `repos`
+# Your GitHub Personal Access Token (https://github.com/settings/tokens) with
+# the `repo:status` and `repo_deployment` scopes selected
+GITHUB_TOKEN=12345
+# The repository you are going to track the deployments for
 GITHUB_REPOSITORY=openSUSE/open-build-service
+# The branch you are going to track the deployments for
 GITHUB_BRANCH=master

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 bin/*
 tmp/*
+docker-compose.override.yml
 vendor
 .bundle

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
 bin/*
+tmp/*
 vendor
 .bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,15 @@
-FROM registry.opensuse.org/opensuse/leap:15.3
+FROM registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/ansible-obs-base:latest
 
 ARG USER_ID=1000
 ARG GROUP_ID=100
 ARG USER_NAME=foo
 
-RUN zypper ar -f -G https://download.opensuse.org/repositories/devel:/languages:/ruby/openSUSE_Leap_15.3/devel:languages:ruby.repo
-RUN zypper --gpg-auto-import-keys refresh
-
-RUN zypper -n install openssh-clients ansible ruby3.1-devel bash git libxml2-devel gcc make shadow vim curl libxslt-devel
-RUN zypper -q clean -a
-
 RUN useradd -l -u ${USER_ID} -g ${GROUP_ID} --home-dir /home/${USER_NAME} --create-home ${USER_NAME}
+ADD entrypoint.sh /
 
-# Ensure there is bundle command without ruby suffix
-RUN for i in ruby gem irb bundle bundler; do ln -s /usr/bin/$i.ruby3.1 /usr/local/bin/$i; done
+USER ${USER_NAME}
 
-WORKDIR /home/${USER_NAME}/ansible-obs
-ADD Gemfile /home/${USER_NAME}/ansible-obs
-ADD Gemfile.lock /home/${USER_NAME}/ansible-obs
-RUN bundle.ruby3.1 config build.nokogiri --use-system-libraries && bundle.ruby3.1 install
-ADD "entrypoint.sh" /
+RUN ln -sf /home/${USER_NAME}/ansible-obs/tmp/bash_history /home/${USER_NAME}/.bash_history
 
 ENTRYPOINT ["bash", "-c", "/entrypoint.sh"]
+

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-all:
-	docker-compose build --build-arg USER_ID=$(shell id -u)
-
-run:
-	docker-compose run --rm -u $(shell whoami) ansible-obs

--- a/README.md
+++ b/README.md
@@ -1,24 +1,120 @@
 [![CircleCI](https://circleci.com/gh/openSUSE/ansible-obs.svg?style=svg)](https://circleci.com/gh/openSUSE/ansible-obs)
 
-## How to run it in production, using Docker:
+## Installation
 
-First build the image with:
+Build the docker image
 
-run `make`
-
-
-To run the container you call:
-
-```
-docker-compose run --rm -u $(whoami) ansible-obs
+```shell
+docker-compose build --no-cache
 ```
 
-Inside the container, you should list all the `obs_deploy` commands by running:
+⚠️ Note: The container will run with a user with your username, the UID 1000 and the GID 100 by default.
+If you need something else: `cp docker-compose.override.yml.example docker-compose.override.yml` and set it up.
+
+## Configuration
+
+You should need to do this only once...
+
+1. Check that your VPN is working and you can access the reference server.
+1. Set the correct SSH hostname in [inventory/production.yml](https://github.com/openSUSE/ansible-obs/blob/master/inventory/production.yml).
+1. Set the correct credentials and information regarding the GitHub Deployments in .env
+
+    ```shell
+    cp .env.template .env
+    vi .env
+    ```
+
+## Usage
+
+1. Run the container (this opens a shell):
+
+    ```shell
+    docker-compose run --rm ansible-obs
+    ```
+
+1. Check the diff of the changes you are going to introduce
+
+    ```shell
+    bin/obs_deploy check-diff
+    ```
+
+1. Check if there is a monkey patch in the server and act accordingly
+1. Deploy using the correct playbook, they are described below.
+
+    ```shell
+    ansible-playbook -i inventory/production.yml $playbook
+    ```
+
+1. Or check out the other things you can do with `obs_deploy` and `ogd`
+
+    ```shell
+    bin/obs_deploy -h
+    ...
+    bin/ogd --help
+    ```
+
+## Playbooks
+
+Depending on what you deploy, we have some different playbooks...
+
+### Deployment without migration
+
+Most of our deployments only contain code changes that don't introduce any changes on the database schema, data or require downtime for any other reasons.
+
+```shell
+ansible-playbook -i inventory/production.yml deploy_without_migration.yml
+```
+
+If we detect that there is any schema or data migration in the deployment, this will abort. If that is the case, check the other options below.
+
+### Deployment with migration online
+
+Many database/data migrations are non-disruptive and therefore don't cause downtimes. This playbook will **not** put
+the OBS into maintenance mode and apply the migrations online.
+
+⚠️ Note: You need to check upfront if the database/data migration is a non-disruptive one, the playbook is not able to distinguish between those two cases. Once you've confirmed that there won't be downtime needed, go ahead. Otherwise, see the other option below.
 
 ```
-bin/obs_deploy
+ansible-playbook -i inventory/production.yml deploy_with_migration_without_downtime.yml
 ```
 
-Now if, your VPN is up and running, you are able to call `ssh root@obs` from the container.
+### Deployment with migration with downtime
 
-Go to the [Wiki](https://github.com/openSUSE/open-build-service/wiki/Deployment-of-build.opensuse.org) to read more about how to deploy with `ansible-obs`.
+In many cases, database migrations require to stop all interactions of the application with the database while they are getting executed. Therefore causing downtime.
+
+⚠️ NOTE: Database migrations with downtime should run in the maintenance window Thursday 8AM - 10AM CET/CEST
+
+```
+ansible-playbook -i inventory/production.yml deploy_with_migration.yml
+```
+
+## Troubleshooting
+
+If shit has hit the fan, see our production page in the developer wiki
+
+https://github.com/openSUSE/open-build-service/wiki/build.opensuse.org
+
+## Monkey-patching
+
+As far as possible, when you find a bug, act as usual: create a Pull Request, wait for it to be reviewed, merged and then wait until the changes can be deployed.
+
+In very rare cases this process might take too long. For example, when the bug is destroying data, blocking work for a large amount of users or even killing the whole application. If you need to monkey-patch something:
+
+1. Block the deployment until you have a proper fix
+    ```shell
+    ogd lock --reason "There is a monkey patch in app/blah/blubb.rb"
+    ```
+1. Whatever you patched, open a draft PR with it and attach the monkey patch label
+1. Point to the PR in /etc/motd on production
+    ```shell
+    APPLIED MONKEY PATCHES
+    ----------------------
+
+    Henne: https://github.com/openSUSE/open-build-service/pull/12798
+    ```
+1. Once the PR is merged, unblock the deployment
+    ```shell
+    ogd unlock
+    ```
+1. Remove things from /etc/motd on production
+

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,9 @@
+version: '3.3'
+services:
+  ansible-obs:
+    build:
+      context: .
+      args:
+        USER_NAME: hans
+        USER_ID: 0815
+        GROUP_ID: 500

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       context: .
       args:
         USER_NAME: ${USER}
-        
     volumes:
       - ~/.ssh/:/home/${USER}/.ssh:ro
       - ${PWD}:/home/${USER}/ansible-obs

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,9 @@
-#!/bin/bash
+#!/bin/bash -l
 
-cd /home/$USER/ansible-obs
-bundle.ruby3.1 config set --local deployment 'true' &&
+cd ~/ansible-obs
+
+bundle.ruby3.1 config set --local path 'vendor/bundle' &&
 bundle.ruby3.1 config build.nokogiri --use-system-libraries &&
-bundle.ruby3.1 install &&
-bundle.ruby3.1 binstubs --all
-
-echo "Have a lot of fun"
-
-bash -i
+bundle.ruby3.1 install --jobs=4 --retry=3 &&
+bundle.ruby3.1 binstubs --all &&
+/bin/bash -l


### PR DESCRIPTION
- Use a base image for Docker build. The software we install only seldomly changes, let OBS handle this.
- Introduces bash history outside the container so it survives desctruction.
- The documentation should be with the repo, no need to send people around to other wiki pages.
- introduces docker-compose.override.yml to override build variables like we do in the main repo.
 



    

    


