### PR TITLE
Add check for local changes in obs-api package using rpm

### DIFF
--- a/deploy_without_migration.yml
+++ b/deploy_without_migration.yml
@@ -1,10 +1,13 @@
 ---
   - name: Deploy obs-api package
     hosts: obs
+    vars:
+      overwrite_local_changes: false
 
     pre_tasks:
       - include_tasks: ./includes/pending-migration.yml
       - include_tasks: ./includes/deployment-block.yml
+      - include_tasks: ./includes/check-local-changes.yml
       - name: zypper unlock
         block:
           - include_tasks: ./includes/zypper-unlock.yml

--- a/deploy_without_migration.yml
+++ b/deploy_without_migration.yml
@@ -2,7 +2,7 @@
   - name: Deploy obs-api package
     hosts: obs
     vars:
-      overwrite_local_changes: false
+      skip_local_rpm_check: false
 
     pre_tasks:
       - include_tasks: ./includes/pending-migration.yml

--- a/includes/check-local-changes.yml
+++ b/includes/check-local-changes.yml
@@ -1,9 +1,9 @@
-# requires overwrite_local_changes (bool, dafault to false) to be set
+# requires skip_local_rpm_check (bool, dafault to false) to be set
 ---
   - name: Verify local changes
-    shell: "rpm -V obs-api"
+    shell: rpm -V --noconfig obs-api
     changed_when: false
     ignore_errors: false
     become: true
     when:
-      - not overwrite_local_changes
+      - not skip_local_rpm_check

--- a/includes/check-local-changes.yml
+++ b/includes/check-local-changes.yml
@@ -1,0 +1,9 @@
+# requires overwrite_local_changes (bool, dafault to false) to be set
+---
+  - name: Verify local changes
+    shell: "rpm -V obs-api"
+    changed_when: false
+    ignore_errors: false
+    become: true
+    when:
+      - not overwrite_local_changes


### PR DESCRIPTION
Add a playbook that will fail the deployment if there are local changes to the package obs-api. The verification is done via rpm and in my tests the changes are printed if the shell command has non zero return code.

Requires a bool (overwrite_local_changes, default to false) to switch mode in case the local changes need to be overwritten.

Since I cannot fully test, for this draft I'm adding the include just in deploy_without_migration.yml for completion.