### PR TITLE
Add a report of deployment to influxdb

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -16,3 +16,10 @@
     notify: 
       - ensure systemd
       - check_http_server_running
+
+  - name: report deployment to influxdb
+    ansible.builtin.uri:
+      url: http://errbit2.obsmgmt.opensuse.org:48086/write?db=SystemHealthMonitoring
+      method: POST
+      body: "deploymentcount value=1i"
+      status_code: 204


### PR DESCRIPTION
so that we can alert in Grafana
when deployment was forgotten for too long