### PR TITLE
Revert "Add role to replace the servers url key of the API documentation"

### DIFF
--- a/deploy_with_migration.yml
+++ b/deploy_with_migration.yml
@@ -21,8 +21,6 @@
           - include_role:
               name: run_migrations
           - include_role:
-              name: replace_servers_url_with_api_o_o
-          - include_role:
               name: enable_flipper_features_for_group
           - include_role:
               name: unset_apache_maintenance_mode

--- a/deploy_with_migration_without_downtime.yml
+++ b/deploy_with_migration_without_downtime.yml
@@ -20,8 +20,6 @@
           - include_role:
               name: run_migrations
           - include_role:
-              name: replace_servers_url_with_api_o_o
-          - include_role:
               name: enable_flipper_features_for_group
         when: deployment_allowed is succeeded and no_pending_migration is failed
 

--- a/deploy_without_migration.yml
+++ b/deploy_without_migration.yml
@@ -13,12 +13,10 @@
     tasks:
       - name: Without Migration
         block:
-          - include_role:
+          - include_role: 
               name: refresh_repositories
-          - include_role:
+          - include_role: 
               name: deploy
-          - include_role:
-              name: replace_servers_url_with_api_o_o
           - include_role:
               name: enable_flipper_features_for_group
         when: deployment_allowed is succeeded and no_pending_migration is succeeded

--- a/replace_servers_url_with_api_o_o.yml
+++ b/replace_servers_url_with_api_o_o.yml
@@ -1,5 +1,0 @@
----
-- name: Replace servers url with api.opensuse.org
-  hosts: obs
-  roles:
-    - replace_servers_url_with_api_o_o

--- a/roles/replace_servers_url_with_api_o_o/tasks/main.yml
+++ b/roles/replace_servers_url_with_api_o_o/tasks/main.yml
@@ -1,6 +1,0 @@
----
-  - name: Replace servers url in API documentation
-    ansible.builtin.lineinfile:
-      path: '/srv/www/obs/api/public/apidocs-new/OBS-v2.10.50.yaml'
-      regexp: "^  - url: '/'$"
-      line: "  - url: 'https://api.opensuse.org/'"


### PR DESCRIPTION
Reverts openSUSE/ansible-obs#80

We had to solve this differently (redirect) because of the login proxy setup on production...