### PR TITLE
Upgrade python to 3.9 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ workflows:
 jobs:
   linter:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.9
     steps:
       - checkout
       - python/install-packages:


### PR DESCRIPTION
This is a requirement for ansible 7.0.0, already upgraded in #75.