### PR TITLE
Remove `version` top-level element from `docker compose` files

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,4 +1,3 @@
-version: '3.3'
 services:
   ansible-obs:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 services:
   ansible-obs:
     environment:


### PR DESCRIPTION
When running docker compose commands, prevent this warning from happening: "WARN ... `version` is obsolete"

See: https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-top-level-element