### PR TITLE
Deprecated no longer available warn parameter

### DIFF
--- a/includes/zypper-lock.yml
+++ b/includes/zypper-lock.yml
@@ -1,5 +1,3 @@
 ---
   - name: lock obs-api
     shell: zypper al obs-api
-    args:
-      warn: false # To remove the warning `Consider using the zypper module rather than running 'zypper'`. This isn't possible since the module doesn't support locking packages.

--- a/includes/zypper-unlock.yml
+++ b/includes/zypper-unlock.yml
@@ -1,5 +1,3 @@
 ---
   - name: unlock obs-api
     shell: zypper rl obs-api
-    args:
-      warn: false # To remove the warning `Consider using the zypper module rather than running 'zypper'`. This isn't possible since the module doesn't support unlocking packages.

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -19,8 +19,3 @@
   shell: "{{ check_url }}"
   delegate_to: localhost
   listen: check_http_server_running
-  # Disable warning: `Consider using the get_url or uri module rather than running 'curl'.`
-  # `curl -f` fails fast by returning an error whenever the server responds with an HTTP error code.
-  # This isn't possible with the `get_url` and `uri` modules, so we have to use `curl` directly.
-  args:
-    warn: false

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -11,7 +11,6 @@
   - name: zypper up 'obs-api'
     command: 
       cmd: zypper -n update --best-effort --details obs-api
-      warn: false
     when: new_version_available.rc == 0
     notify: 
       - ensure systemd


### PR DESCRIPTION
https://github.com/ansible/ansible/blob/v2.11.0/changelogs/CHANGELOG-v2.11.rst#deprecated-features

Drop the `warn` parameter as it results in an `error` now since `v2.11.0`